### PR TITLE
Show inflow in activity column

### DIFF
--- a/snaver/views.py
+++ b/snaver/views.py
@@ -330,7 +330,7 @@ class BudgetView(ListView):
                                 transactions__receipt_date__lte=last_day,
                                 transactions__receipt_date__gte=first_day,
                             ), distinct=True)
-                        - Sum('transactions__outflow',
+                        + Sum('transactions__outflow',
                               filter=Q(
                                   transactions__receipt_date__lte=last_day,
                                   transactions__receipt_date__gte=first_day,

--- a/snaver/views.py
+++ b/snaver/views.py
@@ -325,11 +325,17 @@ class BudgetView(ListView):
                 queryset=Subcategory.objects.all().order_by('order', '-created_on')
                     .annotate(
                     activity=Coalesce(
-                        Sum('transactions__outflow',
+                        Sum('transactions__inflow',
                             filter=Q(
                                 transactions__receipt_date__lte=last_day,
                                 transactions__receipt_date__gte=first_day,
-                            ), distinct=True), Decimal(0.00)
+                            ), distinct=True)
+                        - Sum('transactions__outflow',
+                              filter=Q(
+                                  transactions__receipt_date__lte=last_day,
+                                  transactions__receipt_date__gte=first_day,
+                              ), distinct=True)
+                        , Decimal(0.00)
                     ),
                     available=Coalesce(
                         Sum('details__budgeted_amount',


### PR DESCRIPTION
Activity now shows Inflow + Outflow

We have 2 options:
1. Inflow - Outflow
    On screenshot "Mixed" category has 500 inflow and 500 outflow. It shows 0 activity but -500 available.

    ![Screenshot from 2021-07-06 19-57-02](https://user-images.githubusercontent.com/138645/124645965-5ce57600-de94-11eb-9381-69578f18b907.png)

1. Inflow + Outflow
    We could also change Activity to be Inflow + Outflow. Activity would then always be positive:

    ![Screenshot from 2021-07-06 20-01-25](https://user-images.githubusercontent.com/138645/124646463-f6148c80-de94-11eb-873f-1ff1d3174fb9.png)

Which is better?
